### PR TITLE
fix failure on set rootful

### DIFF
--- a/macos_create_microshift_plus.sh
+++ b/macos_create_microshift_plus.sh
@@ -5,11 +5,12 @@ start=$(date +'%s')
 echo "Creating Podman Machine..."
 podman machine init --cpus 4 --memory 6000 &> /dev/null
 
+echo "Setting rootful mode..."
+podman machine set --rootful
+
 echo "Starting Podman Machine..."
 podman machine start &> /dev/null
 
-echo "Setting rootful mode..."
-podman machine set --rootful
 
 echo "Launching Microshift..."
 podman run -d --name microshift --privileged -v microshift-data:/var/lib -p 6443:6443 -p 80:80 -p 8080:8080 quay.io/microshift/microshift-aio:latest &> /dev/null


### PR DESCRIPTION

```console
> ./macos_create_microshift_plus.sh                                                                                                             Creating Podman Machine...
Starting Podman Machine...                                                                                                                                                  Setting rootful mode...
Error: cannot change settings while the vm is running, run 'podman machine stop' first
```